### PR TITLE
Fix 'main' path in package.json to point to 'lib' folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-country-region-selector",
   "version": "1.0.0",
   "description": "CountryDropdown and RegionDropdown React components for your forms.",
-  "main": "dist/rcrs.js",
+  "main": "lib/rcrs.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The `dist` path is meant to be used with `bower`.