### PR TITLE
Export raw country/region data for apps that need it beyond select boxes

### DIFF
--- a/src/rcrs.js
+++ b/src/rcrs.js
@@ -227,4 +227,4 @@ function _filterCountries (countries, whitelist, blacklist) {
 }
 
 
-export { CountryDropdown, RegionDropdown };
+export { CountryDropdown, RegionDropdown, CountryRegionData };


### PR DESCRIPTION
An example of needing the raw data would be converting country codes back into country names for  display to the user outside of a select box.