### PR TITLE
Fix bug: Prevent crash when regions array is empty due to invalid country

### DIFF
--- a/dist/rcrs.js
+++ b/dist/rcrs.js
@@ -1197,7 +1197,7 @@ var RegionDropdown = (function (_React$Component2) {
 
       // this could happen if the user is managing the state of the region/country themselves and screws up passing
       // in a valid country
-      if (!regions || regions.length === 0) {
+      if (!regions) {
         console.error('Error. Unknown country passed: ' + country + '. If you\'re passing a country shortcode, be sure to include countryValueType="short" on the RegionDropdown');
         return [];
       }

--- a/dist/rcrs.js
+++ b/dist/rcrs.js
@@ -1197,7 +1197,7 @@ var RegionDropdown = (function (_React$Component2) {
 
       // this could happen if the user is managing the state of the region/country themselves and screws up passing
       // in a valid country
-      if (!regions) {
+      if (!regions || regions.length === 0) {
         console.error('Error. Unknown country passed: ' + country + '. If you\'re passing a country shortcode, be sure to include countryValueType="short" on the RegionDropdown');
         return [];
       }

--- a/examples/dist/bundle.js
+++ b/examples/dist/bundle.js
@@ -1213,7 +1213,7 @@ var RegionDropdown = (function (_React$Component2) {
 
       // this could happen if the user is managing the state of the region/country themselves and screws up passing
       // in a valid country
-      if (!regions) {
+      if (!regions || regions.length === 0) {
         console.error('Error. Unknown country passed: ' + country + '. If you\'re passing a country shortcode, be sure to include countryValueType="short" on the RegionDropdown');
         return [];
       }

--- a/examples/dist/examples.js
+++ b/examples/dist/examples.js
@@ -599,7 +599,7 @@ var RegionDropdown = (function (_React$Component2) {
 
       // this could happen if the user is managing the state of the region/country themselves and screws up passing
       // in a valid country
-      if (!regions) {
+      if (!regions || regions.length === 0) {
         console.error('Error. Unknown country passed: ' + country + '. If you\'re passing a country shortcode, be sure to include countryValueType="short" on the RegionDropdown');
         return [];
       }

--- a/examples/dist/standalone.js
+++ b/examples/dist/standalone.js
@@ -1197,7 +1197,7 @@ var RegionDropdown = (function (_React$Component2) {
 
       // this could happen if the user is managing the state of the region/country themselves and screws up passing
       // in a valid country
-      if (!regions) {
+      if (!regions || regions.length === 0) {
         console.error('Error. Unknown country passed: ' + country + '. If you\'re passing a country shortcode, be sure to include countryValueType="short" on the RegionDropdown');
         return [];
       }

--- a/lib/rcrs.js
+++ b/lib/rcrs.js
@@ -194,7 +194,7 @@ var RegionDropdown = (function (_React$Component2) {
 
       // this could happen if the user is managing the state of the region/country themselves and screws up passing
       // in a valid country
-      if (!regions) {
+      if (!regions || regions.length === 0) {
         console.error('Error. Unknown country passed: ' + country + '. If you\'re passing a country shortcode, be sure to include countryValueType="short" on the RegionDropdown');
         return [];
       }

--- a/src/rcrs.js
+++ b/src/rcrs.js
@@ -128,7 +128,7 @@ class RegionDropdown extends React.Component {
 
     // this could happen if the user is managing the state of the region/country themselves and screws up passing
     // in a valid country
-    if (!regions) {
+    if (!regions || regions.length === 0) {
       console.error('Error. Unknown country passed: ' + country + '. If you\'re passing a country shortcode, be sure to include countryValueType="short" on the RegionDropdown');
       return [];
     }


### PR DESCRIPTION
When country code is undefined, regions array is an empty array rather than falsey. Add checker for zero length array to throw console.error